### PR TITLE
fix(AG-3746): Change ShiftLeft Download Location

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -15,9 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Execute Upwind CI scan plugin
-        uses: upwindsecurity/shiftleft-create-image-publish-event-action@${GITHUB_SHA}
+        uses: ./
         with:
-          upwind_client_id: ${{ secrets.INTEGRATION_UPWIND_CI_EVENT_DEV_CLIENT_ID }}
-          upwind_client_secret: ${{ secrets.INTEGRATION_UPWIND_CI_EVENT_DEV_CLIENT_SECRET }}
-          upwind_uri: "upwind.dev"
+          upwind_client_id: ${{ secrets.UPWIND_CLIENT_ID }}
+          upwind_client_secret: ${{ secrets.UPWIND_CLIENT_SECRET }}
+          upwind_uri: upwind.dev
           docker_image: 'ubuntu:22.04'

--- a/action.yml
+++ b/action.yml
@@ -36,30 +36,52 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Get auth token
-      id: get_auth_token
+    - name: Download Binary
+      id: download_binary
       shell: bash
       run: |
-        TOKEN=$(curl -sSL -X POST \
-          --url https://oauth.${{ inputs.upwind_uri }}/oauth/token \
-          --data 'audience=https://agent.${{ inputs.upwind_uri }}' \
-          --data "client_id=${{ inputs.upwind_client_id }}" \
-          --data "client_secret=${{ inputs.upwind_client_secret }}" \
-          --data grant_type=client_credentials | jq -r '.access_token')
-        echo "value=$TOKEN" >> $GITHUB_OUTPUT
-    - name: Download sensor binary
-      shell: bash
-      run: |
-        UPWIND_AGENT=shiftleft
-        AGENT_OUTPUT=$GITHUB_WORKSPACE/$UPWIND_AGENT
-        UPWIND_AGENT_URL=https://releases.${{ inputs.upwind_uri }}/$UPWIND_AGENT/stable/$UPWIND_AGENT
-        curl -fsS -H "Authorization: Bearer ${{ steps.get_auth_token.outputs.value }}" -L $UPWIND_AGENT_URL -o $AGENT_OUTPUT
-        chmod +x $AGENT_OUTPUT
-        echo "Info: Upwind sensor binary downloaded to: $AGENT_OUTPUT"
+        response=$(curl -sSL -X POST \
+        --url "https://oauth.${{ inputs.upwind_uri }}/oauth/token" \
+        --data "audience=https://agent.${{ inputs.upwind_uri }}" \
+        --data "client_id=${{ inputs.upwind_client_id }}" \
+        --data "client_secret=${{ inputs.upwind_client_secret }}" \
+        --data "grant_type=client_credentials")
+
+        if ! TOKEN=$(echo "$response" | jq -r '.access_token // empty' 2>/dev/null); then
+          echo "Failed to parse JSON response: $response" >&2
+          exit 1
+        elif [ -z "$TOKEN" ]; then
+          echo "No access_token found in response: $response" >&2
+          exit 1
+        fi
+
+        OS=$(uname | tr '[:upper:]' '[:lower:]')
+        ARCH=$(uname -m | tr '[:upper:]' '[:lower:]')
+
+        case "$ARCH" in
+          x86_64)
+            ARCH="amd64"
+            ;;
+          aarch64|arm64)
+            ARCH="arm64"
+            ;;
+          *)
+            echo "Unsupported architecture: $ARCH" >&2
+            exit 1
+            ;;
+        esac
+
+        UPWIND_AGENT="shiftleft"
+        AGENT_OUTPUT="./$UPWIND_AGENT"
+        UPWIND_AGENT_URL="https://releases.${{ inputs.upwind_uri }}/$UPWIND_AGENT/stable/$OS/$ARCH/$UPWIND_AGENT-$OS-$ARCH"
+
+        echo "Downloading from $UPWIND_AGENT_URL"
+        curl -fsS -H "Authorization: Bearer $TOKEN" -L "$UPWIND_AGENT_URL" -o "$AGENT_OUTPUT"
+        chmod +x "$AGENT_OUTPUT"
     - name: Execute scan against the docker image
       shell: bash
       run: |
-        sudo ${{ github.workspace }}/shiftleft event \
+        sudo ./shiftleft event \
           --source=GITHUB_ACTIONS \
           --initiator=${GITHUB_TRIGGERING_ACTOR} \
           --event-type=IMAGE_PUBLISH \


### PR DESCRIPTION
The Github Workspace is not always available in some instances so instead just use the current directory